### PR TITLE
add yak bak to CFP tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ A list of tools you can use (in alphabetical order):
 - `Papercall <https://www.papercall.io/>`_
 - `pretalx <https://pretalx.com/p/about/>`_
 - `Symposion <https://github.com/pinax/symposion>`_
+- `Yak Bak <https://gitlab.com/bigapplepy/yak-bak>`_ (developed/used by PyGotham)
 - ???
 
 Ticketing


### PR DESCRIPTION
I was chatting with the pygotham people (e.g., @dirn) about their tool a little while back. It's built for crowd-sourced voting on CFPs. Figured others might like to know about it.